### PR TITLE
Update style.css

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,3 +1,3 @@
-.mt-signature{
+[id$=mt-signature]{
     display: none !important;
 }


### PR DESCRIPTION
The extension fails, because it relies on a class selector .mt-signature, while Mailtrack uses an ID selector #mt-signature when composing emails and prepends a unique prefix to the ID selector, such as #xxxxxxxxxxxx_mt-signature, when displaying SENT emails. Updating the extension to use an "ends with" wildcard ID selector [id$=mt-signature] covers both instances and fixes the broken extension.